### PR TITLE
last build barely made it in time

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -24,7 +24,7 @@ jobs:
   Build:
     runs-on: ubuntu-latest
 
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     permissions:
       contents: read


### PR DESCRIPTION
* when cache is no good, the build is very slow; especially because of QEMU emulation of ARM64